### PR TITLE
Refactored findPatch and findQuad methods

### DIFF
--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainPatch.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainPatch.java
@@ -114,6 +114,8 @@ public class TerrainPatch extends Geometry {
 
     protected float[] lodEntropy;
 
+    private final int DIR_RIGHT = 0, DIR_DOWN = 1, DIR_LEFT = 2, DIR_TOP = 3;
+
     public TerrainPatch() {
         super("TerrainPatch");
         setBatchHint(BatchHint.Never);
@@ -303,6 +305,105 @@ public class TerrainPatch extends Geometry {
      */
     public Triangle[] getGridTriangles(float x, float z) {
         return geomap.getGridTrianglesAtPoint(x, z, getWorldScale() , getWorldTranslation());
+    }
+
+    protected TerrainPatch findPatch(int direction) {
+        switch (direction) {
+            case DIR_RIGHT  : return getRightNeighbourPatch();
+            case DIR_DOWN   : return getDownNeighbourPatch();
+            case DIR_LEFT   : return getLeftNeighbourPatch();
+            case DIR_TOP    : return getTopNeighbourPatch();
+        }
+
+        return null;
+    }
+
+    private TerrainPatch getRightNeighbourPatch() {
+        TerrainQuad parent = (TerrainQuad) this.getParent();
+        TerrainQuad neighbourQuad;
+
+        switch(quadrant) {
+            case 1: return parent.getPatch(3);
+            case 2: return parent.getPatch(4);
+            case 3:
+                neighbourQuad = parent.findQuad(DIR_RIGHT);
+                if (neighbourQuad != null)
+                    return neighbourQuad.getPatch(1);
+                break;
+            case 4:
+                neighbourQuad = parent.findQuad(DIR_RIGHT);
+                if (neighbourQuad != null)
+                    return neighbourQuad.getPatch(2);
+                break;
+        }
+
+        return null;
+    }
+
+    private TerrainPatch getDownNeighbourPatch() {
+        TerrainQuad parent = (TerrainQuad) this.getParent();
+        TerrainQuad neighbourQuad;
+
+        switch(quadrant) {
+            case 1: return parent.getPatch(2);
+            case 2:
+                neighbourQuad = parent.findQuad(DIR_DOWN);
+                if (neighbourQuad != null)
+                    return neighbourQuad.getPatch(1);
+                break;
+            case 3: return parent.getPatch(4);
+            case 4:
+                neighbourQuad = parent.findQuad(DIR_DOWN);
+                if (neighbourQuad != null)
+                    return neighbourQuad.getPatch(3);
+                break;
+        }
+
+        return null;
+    }
+
+    private TerrainPatch getLeftNeighbourPatch() {
+        TerrainQuad parent = (TerrainQuad) this.getParent();
+        TerrainQuad neighbourQuad;
+
+        switch(quadrant) {
+            case 1:
+                neighbourQuad = parent.findQuad(DIR_LEFT);
+                if (neighbourQuad != null)
+                    return neighbourQuad.getPatch(3);
+                break;
+            case 2:
+                neighbourQuad = parent.findQuad(DIR_LEFT);
+                if (neighbourQuad != null)
+                    return neighbourQuad.getPatch(4);
+                break;
+            case 3: return parent.getPatch(1);
+            case 4: return parent.getPatch(2);
+        }
+
+        return null;
+    }
+
+    private TerrainPatch getTopNeighbourPatch() {
+        TerrainQuad parent = (TerrainQuad) this.getParent();
+        TerrainQuad neighbourQuad;
+
+        switch(quadrant) {
+            case 1:
+                neighbourQuad = parent.findQuad(DIR_TOP);
+                if (neighbourQuad != null)
+                    return neighbourQuad.getPatch(2);
+                break;
+            case 2: return parent.getPatch(1);
+            case 3:
+                neighbourQuad = parent.findQuad(DIR_TOP);
+                if (neighbourQuad != null)
+                    return neighbourQuad.getPatch(4);
+                break;
+            case 4: return parent.getPatch(3);
+        }
+
+        return null;
     }
 
     protected void setHeight(List<LocationHeight> locationHeights, boolean overrideHeight) {

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -126,6 +126,8 @@ public class TerrainQuad extends Node implements Terrain {
     private Vector3f lastScale = Vector3f.UNIT_XYZ;
 
     protected NeighbourFinder neighbourFinder;
+
+    private final int DIR_RIGHT = 0, DIR_DOWN = 1, DIR_LEFT = 2, DIR_TOP = 3;
     
     public TerrainQuad() {
         super("Terrain");
@@ -1447,8 +1449,6 @@ public class TerrainQuad extends Node implements Terrain {
     }
 
     protected TerrainQuad findQuad(int direction) {
-        final int DIR_RIGHT = 0, DIR_DOWN = 1, DIR_LEFT = 2, DIR_TOP = 3;
-
         boolean useFinder = false;
         if (getParent() == null || !(getParent() instanceof TerrainQuad)) {
             if (neighbourFinder == null)
@@ -1457,73 +1457,100 @@ public class TerrainQuad extends Node implements Terrain {
                 useFinder = true;
         }
 
-        TerrainQuad pQuad = null;
-        if (!useFinder)
-            pQuad = (TerrainQuad) getParent();
-
-        TerrainQuad neighbourQuad;
-        switch (direction) {
-            case DIR_RIGHT:
-                switch (quadrant) {
-                    case 1: return pQuad.getQuad(3);
-                    case 2: return pQuad.getQuad(4);
-                    case 3:
-                        neighbourQuad = pQuad.findQuad(DIR_RIGHT);
-                        if (neighbourQuad != null)
-                            return neighbourQuad.getQuad(1);
-                        break;
-                    case 4: case DIR_RIGHT:
-                        neighbourQuad = pQuad.findQuad(DIR_RIGHT);
-                        if (neighbourQuad != null)
-                            return neighbourQuad.getQuad(2);
-                        break;
-                }
-            case DIR_DOWN:
-                switch (quadrant) {
-                    case 1: return pQuad.getQuad(2);
-                    case 2: neighbourQuad = pQuad.findQuad(DIR_DOWN);
-                        if (neighbourQuad != null)
-                            return neighbourQuad.getQuad(1);
-                        break;
-                    case 3: return pQuad.getQuad(4);
-                    case 4:
-                        neighbourQuad = pQuad.findQuad(DIR_DOWN);
-                        if (neighbourQuad != null)
-                            return neighbourQuad.getQuad(3);
-                        break;
-                }
-            case DIR_LEFT:
-                switch (quadrant) {
-                    case 1:
-                        neighbourQuad = pQuad.findQuad(DIR_LEFT);
-                        if (neighbourQuad != null)
-                            return neighbourQuad.getQuad(3);
-                        break;
-                    case 2:
-                        neighbourQuad = pQuad.findQuad(DIR_LEFT);
-                        if (neighbourQuad != null)
-                            return neighbourQuad.getQuad(4);
-                        break;
-                    case 3: return pQuad.getQuad(1);
-                    case 4: return pQuad.getQuad(2);
-                }
-            case DIR_TOP:
-                switch (quadrant) {
-                    case 1:
-                        neighbourQuad = pQuad.findQuad(DIR_TOP);
-                        if (neighbourQuad != null)
-                            return neighbourQuad.getQuad(2);
-                        break;
-                    case 2: return pQuad.getQuad(1);
-                    case 3:
-                        neighbourQuad = pQuad.findQuad(DIR_TOP);
-                        if (neighbourQuad != null)
-                            return neighbourQuad.getQuad(4);
-                        break;
-                    case 4: pQuad.getQuad(3);
-                }
+        if (quadrant == 0) {
+            // at the top quad
+            if (useFinder) {
+                TerrainQuad quad = neighbourFinder.getRightQuad(this);
+                return quad;
+            }
         }
 
+        switch (direction) {
+            case DIR_RIGHT  : return getRightNeighbourQuad();
+            case DIR_DOWN   : return getDownNeighbourQuad();
+            case DIR_LEFT   : return getLeftNeighbourQuad();
+            case DIR_TOP    : return getTopNeighbourQuad();
+        }
+
+        return null;
+    }
+
+    private TerrainQuad getRightNeighbourQuad() {
+        TerrainQuad pQuad = (TerrainQuad) getParent();
+        TerrainQuad neighbourQuad;
+        switch (quadrant) {
+            case 1: return pQuad.getQuad(3);
+            case 2: return pQuad.getQuad(4);
+            case 3:
+                neighbourQuad = pQuad.findQuad(DIR_RIGHT);
+                if (neighbourQuad != null)
+                    return neighbourQuad.getQuad(1);
+                break;
+            case 4: case DIR_RIGHT:
+                neighbourQuad = pQuad.findQuad(DIR_RIGHT);
+                if (neighbourQuad != null)
+                    return neighbourQuad.getQuad(2);
+                break;
+        }
+        return null;
+    }
+
+    private TerrainQuad getDownNeighbourQuad() {
+        TerrainQuad pQuad = (TerrainQuad) getParent();
+        TerrainQuad neighbourQuad;
+        switch (quadrant) {
+            case 1: return pQuad.getQuad(2);
+            case 2: neighbourQuad = pQuad.findQuad(DIR_DOWN);
+                if (neighbourQuad != null)
+                    return neighbourQuad.getQuad(1);
+                break;
+            case 3: return pQuad.getQuad(4);
+            case 4:
+                neighbourQuad = pQuad.findQuad(DIR_DOWN);
+                if (neighbourQuad != null)
+                    return neighbourQuad.getQuad(3);
+                break;
+        }
+        return null;
+    }
+
+    private TerrainQuad getLeftNeighbourQuad() {
+        TerrainQuad pQuad = (TerrainQuad) getParent();
+        TerrainQuad neighbourQuad;
+        switch (quadrant) {
+            case 1:
+                neighbourQuad = pQuad.findQuad(DIR_LEFT);
+                if (neighbourQuad != null)
+                    return neighbourQuad.getQuad(3);
+                break;
+            case 2:
+                neighbourQuad = pQuad.findQuad(DIR_LEFT);
+                if (neighbourQuad != null)
+                    return neighbourQuad.getQuad(4);
+                break;
+            case 3: return pQuad.getQuad(1);
+            case 4: return pQuad.getQuad(2);
+        }
+        return null;
+    }
+
+    private TerrainQuad getTopNeighbourQuad() {
+        TerrainQuad pQuad = (TerrainQuad) getParent();
+        TerrainQuad neighbourQuad;
+        switch (quadrant) {
+            case 1:
+                neighbourQuad = pQuad.findQuad(DIR_TOP);
+                if (neighbourQuad != null)
+                    return neighbourQuad.getQuad(2);
+                break;
+            case 2: return pQuad.getQuad(1);
+            case 3:
+                neighbourQuad = pQuad.findQuad(DIR_TOP);
+                if (neighbourQuad != null)
+                    return neighbourQuad.getQuad(4);
+                break;
+            case 4: pQuad.getQuad(3);
+        }
         return null;
     }
 

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -1370,6 +1370,7 @@ public class TerrainQuad extends Node implements Terrain {
         return null;
     }
 
+    @Deprecated
     protected TerrainPatch findRightPatch(TerrainPatch tp) {
         if (tp.getQuadrant() == 1)
             return getPatch(3);
@@ -1390,6 +1391,7 @@ public class TerrainQuad extends Node implements Terrain {
         return null;
     }
 
+    @Deprecated
     protected TerrainPatch findDownPatch(TerrainPatch tp) {
         if (tp.getQuadrant() == 1)
             return getPatch(2);
@@ -1409,7 +1411,7 @@ public class TerrainQuad extends Node implements Terrain {
         return null;
     }
 
-
+    @Deprecated
     protected TerrainPatch findTopPatch(TerrainPatch tp) {
         if (tp.getQuadrant() == 2)
             return getPatch(1);
@@ -1429,6 +1431,7 @@ public class TerrainQuad extends Node implements Terrain {
         return null;
     }
 
+    @Deprecated
     protected TerrainPatch findLeftPatch(TerrainPatch tp) {
         if (tp.getQuadrant() == 3)
             return getPatch(1);

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -1377,12 +1377,12 @@ public class TerrainQuad extends Node implements Terrain {
             return getPatch(4);
         else if (tp.getQuadrant() == 3) {
             // find the patch to the right and ask it for child 1.
-            TerrainQuad quad = findRightQuad();
+            TerrainQuad quad = findQuad(DIR_RIGHT);
             if (quad != null)
                 return quad.getPatch(1);
         } else if (tp.getQuadrant() == 4) {
             // find the patch to the right and ask it for child 2.
-            TerrainQuad quad = findRightQuad();
+            TerrainQuad quad = findQuad(DIR_RIGHT);
             if (quad != null)
                 return quad.getPatch(2);
         }
@@ -1397,11 +1397,11 @@ public class TerrainQuad extends Node implements Terrain {
             return getPatch(4);
         else if (tp.getQuadrant() == 2) {
             // find the patch below and ask it for child 1.
-            TerrainQuad quad = findDownQuad();
+            TerrainQuad quad = findQuad(DIR_DOWN);
             if (quad != null)
                 return quad.getPatch(1);
         } else if (tp.getQuadrant() == 4) {
-            TerrainQuad quad = findDownQuad();
+            TerrainQuad quad = findQuad(DIR_DOWN);
             if (quad != null)
                 return quad.getPatch(3);
         }
@@ -1417,11 +1417,11 @@ public class TerrainQuad extends Node implements Terrain {
             return getPatch(3);
         else if (tp.getQuadrant() == 1) {
             // find the patch above and ask it for child 2.
-            TerrainQuad quad = findTopQuad();
+            TerrainQuad quad = findQuad(DIR_TOP);
             if (quad != null)
                 return quad.getPatch(2);
         } else if (tp.getQuadrant() == 3) {
-            TerrainQuad quad = findTopQuad();
+            TerrainQuad quad = findQuad(DIR_TOP);
             if (quad != null)
                 return quad.getPatch(4);
         }
@@ -1436,11 +1436,11 @@ public class TerrainQuad extends Node implements Terrain {
             return getPatch(2);
         else if (tp.getQuadrant() == 1) {
             // find the patch above and ask it for child 3.
-            TerrainQuad quad = findLeftQuad();
+            TerrainQuad quad = findQuad(DIR_LEFT);
             if (quad != null)
                 return quad.getPatch(3);
         } else if (tp.getQuadrant() == 2) {
-            TerrainQuad quad = findLeftQuad();
+            TerrainQuad quad = findQuad(DIR_LEFT);
             if (quad != null)
                 return quad.getPatch(4);
         }
@@ -1557,6 +1557,7 @@ public class TerrainQuad extends Node implements Terrain {
         return null;
     }
 
+    @Deprecated
     protected TerrainQuad findRightQuad() {
         boolean useFinder = false;
         if (getParent() == null || !(getParent() instanceof TerrainQuad)) {
@@ -1575,11 +1576,11 @@ public class TerrainQuad extends Node implements Terrain {
         else if (quadrant == 2)
             return pQuad.getQuad(4);
         else if (quadrant == 3) {
-            TerrainQuad quad = pQuad.findRightQuad();
+            TerrainQuad quad = pQuad.findQuad(DIR_RIGHT);
             if (quad != null)
                 return quad.getQuad(1);
         } else if (quadrant == 4) {
-            TerrainQuad quad = pQuad.findRightQuad();
+            TerrainQuad quad = pQuad.findQuad(DIR_RIGHT);
             if (quad != null)
                 return quad.getQuad(2);
         } else if (quadrant == 0) {
@@ -1593,6 +1594,7 @@ public class TerrainQuad extends Node implements Terrain {
         return null;
     }
 
+    @Deprecated
     protected TerrainQuad findDownQuad() {
         boolean useFinder = false;
         if (getParent() == null || !(getParent() instanceof TerrainQuad)) {
@@ -1611,11 +1613,11 @@ public class TerrainQuad extends Node implements Terrain {
         else if (quadrant == 3)
             return pQuad.getQuad(4);
         else if (quadrant == 2) {
-            TerrainQuad quad = pQuad.findDownQuad();
+            TerrainQuad quad = pQuad.findQuad(DIR_DOWN);
             if (quad != null)
                 return quad.getQuad(1);
         } else if (quadrant == 4) {
-            TerrainQuad quad = pQuad.findDownQuad();
+            TerrainQuad quad = pQuad.findQuad(DIR_DOWN);
             if (quad != null)
                 return quad.getQuad(3);
         } else if (quadrant == 0) {
@@ -1629,6 +1631,7 @@ public class TerrainQuad extends Node implements Terrain {
         return null;
     }
 
+    @Deprecated
     protected TerrainQuad findTopQuad() {
         boolean useFinder = false;
         if (getParent() == null || !(getParent() instanceof TerrainQuad)) {
@@ -1647,11 +1650,11 @@ public class TerrainQuad extends Node implements Terrain {
         else if (quadrant == 4)
             return pQuad.getQuad(3);
         else if (quadrant == 1) {
-            TerrainQuad quad = pQuad.findTopQuad();
+            TerrainQuad quad = pQuad.findQuad(DIR_TOP);
             if (quad != null)
                 return quad.getQuad(2);
         } else if (quadrant == 3) {
-            TerrainQuad quad = pQuad.findTopQuad();
+            TerrainQuad quad = pQuad.findQuad(DIR_TOP);
             if (quad != null)
                 return quad.getQuad(4);
         } else if (quadrant == 0) {
@@ -1665,6 +1668,7 @@ public class TerrainQuad extends Node implements Terrain {
         return null;
     }
 
+    @Deprecated
     protected TerrainQuad findLeftQuad() {
         boolean useFinder = false;
         if (getParent() == null || !(getParent() instanceof TerrainQuad)) {
@@ -1683,11 +1687,11 @@ public class TerrainQuad extends Node implements Terrain {
         else if (quadrant == 4)
             return pQuad.getQuad(2);
         else if (quadrant == 1) {
-            TerrainQuad quad = pQuad.findLeftQuad();
+            TerrainQuad quad = pQuad.findQuad(DIR_LEFT);
             if (quad != null)
                 return quad.getQuad(3);
         } else if (quadrant == 2) {
-            TerrainQuad quad = pQuad.findLeftQuad();
+            TerrainQuad quad = pQuad.findQuad(DIR_LEFT);
             if (quad != null)
                 return quad.getQuad(4);
         } else if (quadrant == 0) {

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -1446,6 +1446,87 @@ public class TerrainQuad extends Node implements Terrain {
         return null;
     }
 
+    protected TerrainQuad findQuad(int direction) {
+        final int DIR_RIGHT = 0, DIR_DOWN = 1, DIR_LEFT = 2, DIR_TOP = 3;
+
+        boolean useFinder = false;
+        if (getParent() == null || !(getParent() instanceof TerrainQuad)) {
+            if (neighbourFinder == null)
+                return null;
+            else
+                useFinder = true;
+        }
+
+        TerrainQuad pQuad = null;
+        if (!useFinder)
+            pQuad = (TerrainQuad) getParent();
+
+        TerrainQuad neighbourQuad;
+        switch (direction) {
+            case DIR_RIGHT:
+                switch (quadrant) {
+                    case 1: return pQuad.getQuad(3);
+                    case 2: return pQuad.getQuad(4);
+                    case 3:
+                        neighbourQuad = pQuad.findQuad(DIR_RIGHT);
+                        if (neighbourQuad != null)
+                            return neighbourQuad.getQuad(1);
+                        break;
+                    case 4: case DIR_RIGHT:
+                        neighbourQuad = pQuad.findQuad(DIR_RIGHT);
+                        if (neighbourQuad != null)
+                            return neighbourQuad.getQuad(2);
+                        break;
+                }
+            case DIR_DOWN:
+                switch (quadrant) {
+                    case 1: return pQuad.getQuad(2);
+                    case 2: neighbourQuad = pQuad.findQuad(DIR_DOWN);
+                        if (neighbourQuad != null)
+                            return neighbourQuad.getQuad(1);
+                        break;
+                    case 3: return pQuad.getQuad(4);
+                    case 4:
+                        neighbourQuad = pQuad.findQuad(DIR_DOWN);
+                        if (neighbourQuad != null)
+                            return neighbourQuad.getQuad(3);
+                        break;
+                }
+            case DIR_LEFT:
+                switch (quadrant) {
+                    case 1:
+                        neighbourQuad = pQuad.findQuad(DIR_LEFT);
+                        if (neighbourQuad != null)
+                            return neighbourQuad.getQuad(3);
+                        break;
+                    case 2:
+                        neighbourQuad = pQuad.findQuad(DIR_LEFT);
+                        if (neighbourQuad != null)
+                            return neighbourQuad.getQuad(4);
+                        break;
+                    case 3: return pQuad.getQuad(1);
+                    case 4: return pQuad.getQuad(2);
+                }
+            case DIR_TOP:
+                switch (quadrant) {
+                    case 1:
+                        neighbourQuad = pQuad.findQuad(DIR_TOP);
+                        if (neighbourQuad != null)
+                            return neighbourQuad.getQuad(2);
+                        break;
+                    case 2: return pQuad.getQuad(1);
+                    case 3:
+                        neighbourQuad = pQuad.findQuad(DIR_TOP);
+                        if (neighbourQuad != null)
+                            return neighbourQuad.getQuad(4);
+                        break;
+                    case 4: pQuad.getQuad(3);
+                }
+        }
+
+        return null;
+    }
+
     protected TerrainQuad findRightQuad() {
         boolean useFinder = false;
         if (getParent() == null || !(getParent() instanceof TerrainQuad)) {

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -1552,7 +1552,7 @@ public class TerrainQuad extends Node implements Terrain {
                 if (neighbourQuad != null)
                     return neighbourQuad.getQuad(4);
                 break;
-            case 4: pQuad.getQuad(3);
+            case 4: return pQuad.getQuad(3);
         }
         return null;
     }

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -399,10 +399,10 @@ public class TerrainQuad extends Node implements Terrain {
                     TerrainPatch patch = (TerrainPatch) child;
                     if (!patch.searchedForNeighboursAlready) {
                         // set the references to the neighbours
-                        patch.rightNeighbour = findRightPatch(patch);
-                        patch.bottomNeighbour = findDownPatch(patch);
-                        patch.leftNeighbour = findLeftPatch(patch);
-                        patch.topNeighbour = findTopPatch(patch);
+                        patch.rightNeighbour = patch.findPatch(DIR_RIGHT);
+                        patch.bottomNeighbour = patch.findPatch(DIR_DOWN);
+                        patch.leftNeighbour = patch.findPatch(DIR_LEFT);
+                        patch.topNeighbour = patch.findPatch(DIR_TOP);
                         patch.searchedForNeighboursAlready = true;
                     }
                     TerrainPatch right = patch.rightNeighbour;
@@ -498,10 +498,10 @@ public class TerrainQuad extends Node implements Terrain {
                     if(utp != null && utp.lodChanged()) {
                         if (!patch.searchedForNeighboursAlready) {
                             // set the references to the neighbours
-                            patch.rightNeighbour = findRightPatch(patch);
-                            patch.bottomNeighbour = findDownPatch(patch);
-                            patch.leftNeighbour = findLeftPatch(patch);
-                            patch.topNeighbour = findTopPatch(patch);
+                            patch.rightNeighbour = patch.findPatch(DIR_RIGHT);
+                            patch.bottomNeighbour = patch.findPatch(DIR_DOWN);
+                            patch.leftNeighbour = patch.findPatch(DIR_LEFT);
+                            patch.topNeighbour = patch.findPatch(DIR_TOP);
                             patch.searchedForNeighboursAlready = true;
                         }
                         TerrainPatch right = patch.rightNeighbour;
@@ -1747,22 +1747,22 @@ public class TerrainQuad extends Node implements Terrain {
                     continue;
 
                 TerrainPatch tp = (TerrainPatch) child;
-                TerrainPatch right = findRightPatch(tp);
-                TerrainPatch bottom = findDownPatch(tp);
-                TerrainPatch top = findTopPatch(tp);
-                TerrainPatch left = findLeftPatch(tp);
+                TerrainPatch right = tp.findPatch(DIR_RIGHT);
+                TerrainPatch bottom = tp.findPatch(DIR_DOWN);
+                TerrainPatch top = tp.findPatch(DIR_TOP);
+                TerrainPatch left = tp.findPatch(DIR_LEFT);
                 TerrainPatch topLeft = null;
                 if (top != null)
-                    topLeft = findLeftPatch(top);
+                    topLeft = top.findPatch(DIR_LEFT);
                 TerrainPatch bottomRight = null;
                 if (right != null)
-                    bottomRight = findDownPatch(right);
+                    bottomRight = right.findPatch(DIR_DOWN);
                 TerrainPatch topRight = null;
                 if (top != null)
-                    topRight = findRightPatch(top);
+                    topRight = top.findPatch(DIR_RIGHT);
                 TerrainPatch bottomLeft = null;
                 if (left != null)
-                    bottomLeft = findDownPatch(left);
+                    bottomLeft = left.findPatch(DIR_DOWN);
 
                 tp.fixNormalEdges(right, bottom, top, left, bottomRight, bottomLeft, topRight, topLeft);
 

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -1378,12 +1378,12 @@ public class TerrainQuad extends Node implements Terrain {
             return getPatch(4);
         else if (tp.getQuadrant() == 3) {
             // find the patch to the right and ask it for child 1.
-            TerrainQuad quad = findQuad(DIR_RIGHT);
+            TerrainQuad quad = findRightQuad();
             if (quad != null)
                 return quad.getPatch(1);
         } else if (tp.getQuadrant() == 4) {
             // find the patch to the right and ask it for child 2.
-            TerrainQuad quad = findQuad(DIR_RIGHT);
+            TerrainQuad quad = findRightQuad();
             if (quad != null)
                 return quad.getPatch(2);
         }
@@ -1399,11 +1399,11 @@ public class TerrainQuad extends Node implements Terrain {
             return getPatch(4);
         else if (tp.getQuadrant() == 2) {
             // find the patch below and ask it for child 1.
-            TerrainQuad quad = findQuad(DIR_DOWN);
+            TerrainQuad quad = findDownQuad();
             if (quad != null)
                 return quad.getPatch(1);
         } else if (tp.getQuadrant() == 4) {
-            TerrainQuad quad = findQuad(DIR_DOWN);
+            TerrainQuad quad = findDownQuad();
             if (quad != null)
                 return quad.getPatch(3);
         }
@@ -1419,11 +1419,11 @@ public class TerrainQuad extends Node implements Terrain {
             return getPatch(3);
         else if (tp.getQuadrant() == 1) {
             // find the patch above and ask it for child 2.
-            TerrainQuad quad = findQuad(DIR_TOP);
+            TerrainQuad quad = findTopQuad();
             if (quad != null)
                 return quad.getPatch(2);
         } else if (tp.getQuadrant() == 3) {
-            TerrainQuad quad = findQuad(DIR_TOP);
+            TerrainQuad quad = findTopQuad();
             if (quad != null)
                 return quad.getPatch(4);
         }
@@ -1439,11 +1439,11 @@ public class TerrainQuad extends Node implements Terrain {
             return getPatch(2);
         else if (tp.getQuadrant() == 1) {
             // find the patch above and ask it for child 3.
-            TerrainQuad quad = findQuad(DIR_LEFT);
+            TerrainQuad quad = findLeftQuad();
             if (quad != null)
                 return quad.getPatch(3);
         } else if (tp.getQuadrant() == 2) {
-            TerrainQuad quad = findQuad(DIR_LEFT);
+            TerrainQuad quad = findLeftQuad();
             if (quad != null)
                 return quad.getPatch(4);
         }

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -1458,10 +1458,13 @@ public class TerrainQuad extends Node implements Terrain {
         }
 
         if (quadrant == 0) {
-            // at the top quad
             if (useFinder) {
-                TerrainQuad quad = neighbourFinder.getRightQuad(this);
-                return quad;
+                switch (direction) {
+                    case DIR_RIGHT  : return neighbourFinder.getRightQuad(this);
+                    case DIR_DOWN   : return neighbourFinder.getDownQuad(this);
+                    case DIR_LEFT   : return neighbourFinder.getLeftQuad(this);
+                    case DIR_TOP    : return neighbourFinder.getDownQuad(this);
+                }
             }
         }
 

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -1579,11 +1579,11 @@ public class TerrainQuad extends Node implements Terrain {
         else if (quadrant == 2)
             return pQuad.getQuad(4);
         else if (quadrant == 3) {
-            TerrainQuad quad = pQuad.findQuad(DIR_RIGHT);
+            TerrainQuad quad = pQuad.findRightQuad();
             if (quad != null)
                 return quad.getQuad(1);
         } else if (quadrant == 4) {
-            TerrainQuad quad = pQuad.findQuad(DIR_RIGHT);
+            TerrainQuad quad = pQuad.findRightQuad();
             if (quad != null)
                 return quad.getQuad(2);
         } else if (quadrant == 0) {
@@ -1616,11 +1616,11 @@ public class TerrainQuad extends Node implements Terrain {
         else if (quadrant == 3)
             return pQuad.getQuad(4);
         else if (quadrant == 2) {
-            TerrainQuad quad = pQuad.findQuad(DIR_DOWN);
+            TerrainQuad quad = pQuad.findDownQuad();
             if (quad != null)
                 return quad.getQuad(1);
         } else if (quadrant == 4) {
-            TerrainQuad quad = pQuad.findQuad(DIR_DOWN);
+            TerrainQuad quad = pQuad.findDownQuad();
             if (quad != null)
                 return quad.getQuad(3);
         } else if (quadrant == 0) {
@@ -1653,11 +1653,11 @@ public class TerrainQuad extends Node implements Terrain {
         else if (quadrant == 4)
             return pQuad.getQuad(3);
         else if (quadrant == 1) {
-            TerrainQuad quad = pQuad.findQuad(DIR_TOP);
+            TerrainQuad quad = pQuad.findTopQuad();
             if (quad != null)
                 return quad.getQuad(2);
         } else if (quadrant == 3) {
-            TerrainQuad quad = pQuad.findQuad(DIR_TOP);
+            TerrainQuad quad = pQuad.findTopQuad();
             if (quad != null)
                 return quad.getQuad(4);
         } else if (quadrant == 0) {
@@ -1690,11 +1690,11 @@ public class TerrainQuad extends Node implements Terrain {
         else if (quadrant == 4)
             return pQuad.getQuad(2);
         else if (quadrant == 1) {
-            TerrainQuad quad = pQuad.findQuad(DIR_LEFT);
+            TerrainQuad quad = pQuad.findLeftQuad();
             if (quad != null)
                 return quad.getQuad(3);
         } else if (quadrant == 2) {
-            TerrainQuad quad = pQuad.findQuad(DIR_LEFT);
+            TerrainQuad quad = pQuad.findLeftQuad();
             if (quad != null)
                 return quad.getQuad(4);
         } else if (quadrant == 0) {

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainQuad.java
@@ -1463,7 +1463,7 @@ public class TerrainQuad extends Node implements Terrain {
                     case DIR_RIGHT  : return neighbourFinder.getRightQuad(this);
                     case DIR_DOWN   : return neighbourFinder.getDownQuad(this);
                     case DIR_LEFT   : return neighbourFinder.getLeftQuad(this);
-                    case DIR_TOP    : return neighbourFinder.getDownQuad(this);
+                    case DIR_TOP    : return neighbourFinder.getTopQuad(this);
                 }
             }
         }

--- a/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainPatchTest.java
+++ b/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainPatchTest.java
@@ -1,39 +1,13 @@
 package com.jme3.terrain.geomipmap;
 
 import com.jme3.scene.Spatial;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.*;
 
 public class TerrainPatchTest {
 
     final int DIR_RIGHT = 0, DIR_DOWN = 1, DIR_LEFT = 2, DIR_TOP = 3;
-
-    @Rule
-    public final ExpectedException exception = ExpectedException.none();
-
-    private FakeTerrainQuad parentTerrainQuad;
-    private FakeTerrainQuad[] children = new FakeTerrainQuad[4];
-
-    @Before
-    public void init() {
-        for (int i = 0; i < 4; i++) {
-            children[i] = new FakeTerrainQuad();
-        }
-
-        parentTerrainQuad = new FakeTerrainQuad();
-        fakeCreateQuad(parentTerrainQuad, children);
-    }
-
-    private void fakeCreateQuad(FakeTerrainQuad parent, FakeTerrainQuad[] children) {
-        for (int i = 0; i < children.length; i++) {
-            children[i].quadrant = i + 1; // Quadrant starts counting from 1
-            parent.attachChild(children[i]);
-        }
-    }
 
     /**
      * Used to recursively create a nested structure of {@link Spatial}s.

--- a/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainPatchTest.java
+++ b/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainPatchTest.java
@@ -1,0 +1,112 @@
+package com.jme3.terrain.geomipmap;
+
+import com.jme3.scene.Spatial;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.*;
+
+public class TerrainPatchTest {
+
+    final int DIR_RIGHT = 0, DIR_DOWN = 1, DIR_LEFT = 2, DIR_TOP = 3;
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    private FakeTerrainQuad parentTerrainQuad;
+    private FakeTerrainQuad[] children = new FakeTerrainQuad[4];
+
+    @Before
+    public void init() {
+        for (int i = 0; i < 4; i++) {
+            children[i] = new FakeTerrainQuad();
+        }
+
+        parentTerrainQuad = new FakeTerrainQuad();
+        fakeCreateQuad(parentTerrainQuad, children);
+    }
+
+    private void fakeCreateQuad(FakeTerrainQuad parent, FakeTerrainQuad[] children) {
+        for (int i = 0; i < children.length; i++) {
+            children[i].quadrant = i + 1; // Quadrant starts counting from 1
+            parent.attachChild(children[i]);
+        }
+    }
+
+    /**
+     * Used to recursively create a nested structure of {@link Spatial}s.
+     * If nesting level is > 1, root element will be a {@link TerrainQuad}.
+     * Leafs (nesting level 0) are {@link TerrainPatch}es.
+     *
+     * @param nestLevel Nest level to be created.
+     * @return Nested structure of {@link Spatial}s
+     */
+    private Spatial createNestedQuad(int nestLevel) {
+        if (nestLevel == 0) {
+            return new TerrainPatch();
+        }
+
+        FakeTerrainQuad parent = new FakeTerrainQuad();
+        for (int i = 0; i < 4; i++) {
+            Spatial child = createNestedQuad(nestLevel - 1);
+
+            if (child instanceof TerrainPatch) {
+                TerrainPatch patchChild = (TerrainPatch) child;
+                patchChild.quadrant = (short) (i + 1);
+                parent.attachChild(patchChild);
+            } else if (child instanceof TerrainQuad) {
+                FakeTerrainQuad quadChild = (FakeTerrainQuad) child;
+                quadChild.quadrant = i + 1;
+                parent.attachChild(quadChild);
+            }
+        }
+
+        return parent;
+    }
+
+    @Test
+    public void testFindPatch() {
+        // Test for nestlevel 2
+        FakeTerrainQuad root = (FakeTerrainQuad)createNestedQuad(2);
+
+        // Test for all quad children
+        for (int i = 1; i <= 4; i++) {
+            FakeTerrainQuad quadChild = (FakeTerrainQuad) root.getQuad(i);
+
+            // Test for all patch children
+            for (int j = 1; j <= 4; j++) {
+                TerrainPatch patchChild = quadChild.getPatch(j);
+
+                assertNotNull(patchChild);
+
+                assertEquals(patchChild.findPatch(DIR_RIGHT), quadChild.findRightPatch(patchChild));
+                assertEquals(patchChild.findPatch(DIR_DOWN),quadChild.findDownPatch(patchChild));
+                assertEquals(patchChild.findPatch(DIR_LEFT),quadChild.findLeftPatch(patchChild));
+                assertEquals(patchChild.findPatch(DIR_TOP), quadChild.findTopPatch(patchChild));
+
+                // Test nonsense direction
+                assertNull(patchChild.findPatch(-1));
+            }
+        }
+
+        // Test for nestlevel 1
+        root = (FakeTerrainQuad)createNestedQuad(1);
+
+        // Test for all patch children
+        for (int j = 1; j <= 4; j++) {
+            TerrainPatch patchChild = root.getPatch(j);
+
+            assertNotNull(patchChild);
+
+            assertEquals(patchChild.findPatch(DIR_RIGHT), root.findRightPatch(patchChild));
+            assertEquals(patchChild.findPatch(DIR_DOWN),root.findDownPatch(patchChild));
+            assertEquals(patchChild.findPatch(DIR_LEFT),root.findLeftPatch(patchChild));
+            assertEquals(patchChild.findPatch(DIR_TOP), root.findTopPatch(patchChild));
+
+            // Test nonsense direction
+            assertNull(patchChild.findPatch(-1));
+        }
+    }
+}

--- a/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainQuadTest.java
+++ b/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainQuadTest.java
@@ -10,6 +10,8 @@ import org.junit.rules.ExpectedException;
 
 public class TerrainQuadTest {
 
+    final int DIR_RIGHT = 0, DIR_DOWN = 1, DIR_LEFT = 2, DIR_TOP = 3;
+
     @Rule
     public final ExpectedException exception = ExpectedException.none();
 
@@ -122,18 +124,18 @@ public class TerrainQuadTest {
         FakeTerrainQuad topLeftChild = (FakeTerrainQuad) root.getQuad(1);
         FakeTerrainQuad topRight = (FakeTerrainQuad) root.getQuad(3);
 
-        assertEquals(root.findRightQuad(), null);
-        assertEquals(topLeftChild.findRightQuad(), topRight); // Confirm position of two parent quads
+        assertEquals(root.findQuad(DIR_RIGHT), null);
+        assertEquals(topLeftChild.findQuad(DIR_RIGHT), topRight); // Confirm position of two parent quads
 
         // Check quad children of parent
-        assertEquals(topLeftChild.getQuad(1).findRightQuad(), topLeftChild.getQuad(3));
-        assertEquals(topLeftChild.getQuad(2).findRightQuad(), topLeftChild.getQuad(4));
-        assertEquals(topLeftChild.getQuad(3).findRightQuad(), topRight.getQuad(1));
-        assertEquals(topLeftChild.getQuad(4).findRightQuad(), topRight.getQuad(2));
+        assertEquals(topLeftChild.getQuad(1).findQuad(DIR_RIGHT), topLeftChild.getQuad(3));
+        assertEquals(topLeftChild.getQuad(2).findQuad(DIR_RIGHT), topLeftChild.getQuad(4));
+        assertEquals(topLeftChild.getQuad(3).findQuad(DIR_RIGHT), topRight.getQuad(1));
+        assertEquals(topLeftChild.getQuad(4).findQuad(DIR_RIGHT), topRight.getQuad(2));
 
         // Check non-existing neighbour quads
-        assertEquals(topRight.getQuad(3).findRightQuad(), null);
-        assertEquals(topRight.getQuad(4).findRightQuad(), null);
+        assertEquals(topRight.getQuad(3).findQuad(DIR_RIGHT), null);
+        assertEquals(topRight.getQuad(4).findQuad(DIR_RIGHT), null);
     }
 
     @Test
@@ -142,18 +144,18 @@ public class TerrainQuadTest {
         FakeTerrainQuad topLeftChild = (FakeTerrainQuad) root.getQuad(1);
         FakeTerrainQuad downLeftChild = (FakeTerrainQuad) root.getQuad(2);
 
-        assertEquals(root.findDownQuad(), null);
-        assertEquals(topLeftChild.findDownQuad(), downLeftChild); // Confirm position of two parent quads
+        assertEquals(root.findQuad(DIR_DOWN), null);
+        assertEquals(topLeftChild.findQuad(DIR_DOWN), downLeftChild); // Confirm position of two parent quads
 
         // Check quad children of parent
-        assertEquals(topLeftChild.getQuad(1).findDownQuad(), topLeftChild.getQuad(2));
-        assertEquals(topLeftChild.getQuad(2).findDownQuad(), downLeftChild.getQuad(1));
-        assertEquals(topLeftChild.getQuad(3).findDownQuad(), topLeftChild.getQuad(4));
-        assertEquals(topLeftChild.getQuad(4).findDownQuad(), downLeftChild.getQuad(3));
+        assertEquals(topLeftChild.getQuad(1).findQuad(DIR_DOWN), topLeftChild.getQuad(2));
+        assertEquals(topLeftChild.getQuad(2).findQuad(DIR_DOWN), downLeftChild.getQuad(1));
+        assertEquals(topLeftChild.getQuad(3).findQuad(DIR_DOWN), topLeftChild.getQuad(4));
+        assertEquals(topLeftChild.getQuad(4).findQuad(DIR_DOWN), downLeftChild.getQuad(3));
 
         // Check non-existing neighbour quads
-        assertEquals(downLeftChild.getQuad(2).findDownQuad(), null);
-        assertEquals(downLeftChild.getQuad(4).findDownQuad(), null);
+        assertEquals(downLeftChild.getQuad(2).findQuad(DIR_DOWN), null);
+        assertEquals(downLeftChild.getQuad(4).findQuad(DIR_DOWN), null);
     }
 
     @Test
@@ -162,18 +164,18 @@ public class TerrainQuadTest {
         FakeTerrainQuad topLeftChild = (FakeTerrainQuad) root.getQuad(1);
         FakeTerrainQuad topRightChild = (FakeTerrainQuad) root.getQuad(3);
 
-        assertEquals(root.findLeftQuad(), null);
-        assertEquals(topRightChild.findLeftQuad(), topLeftChild); // Confirm position of two parent quads
+        assertEquals(root.findQuad(DIR_LEFT), null);
+        assertEquals(topRightChild.findQuad(DIR_LEFT), topLeftChild); // Confirm position of two parent quads
 
         // Check quad children of parent
-        assertEquals(topRightChild.getQuad(1).findLeftQuad(), topLeftChild.getQuad(3));
-        assertEquals(topRightChild.getQuad(2).findLeftQuad(), topLeftChild.getQuad(4));
-        assertEquals(topRightChild.getQuad(3).findLeftQuad(), topRightChild.getQuad(1));
-        assertEquals(topRightChild.getQuad(4).findLeftQuad(), topRightChild.getQuad(2));
+        assertEquals(topRightChild.getQuad(1).findQuad(DIR_LEFT), topLeftChild.getQuad(3));
+        assertEquals(topRightChild.getQuad(2).findQuad(DIR_LEFT), topLeftChild.getQuad(4));
+        assertEquals(topRightChild.getQuad(3).findQuad(DIR_LEFT), topRightChild.getQuad(1));
+        assertEquals(topRightChild.getQuad(4).findQuad(DIR_LEFT), topRightChild.getQuad(2));
 
         // Check non-existing neighbour quads
-        assertEquals(topLeftChild.getQuad(1).findLeftQuad(), null);
-        assertEquals(topLeftChild.getQuad(2).findLeftQuad(), null);
+        assertEquals(topLeftChild.getQuad(1).findQuad(DIR_LEFT), null);
+        assertEquals(topLeftChild.getQuad(2).findQuad(DIR_LEFT), null);
     }
 
     @Test
@@ -182,18 +184,18 @@ public class TerrainQuadTest {
         FakeTerrainQuad topLeftChild = (FakeTerrainQuad) root.getQuad(1);
         FakeTerrainQuad downLeftChild = (FakeTerrainQuad) root.getQuad(2);
 
-        assertEquals(root.findTopQuad(), null);
-        assertEquals(downLeftChild.findTopQuad(), topLeftChild); // Confirm position of two parent quads
+        assertEquals(root.findQuad(DIR_TOP), null);
+        assertEquals(downLeftChild.findQuad(DIR_TOP), topLeftChild); // Confirm position of two parent quads
 
         // Check quad children of parent
-        assertEquals(downLeftChild.getQuad(1).findTopQuad(), topLeftChild.getQuad(2));
-        assertEquals(downLeftChild.getQuad(2).findTopQuad(), downLeftChild.getQuad(1));
-        assertEquals(downLeftChild.getQuad(3).findTopQuad(), topLeftChild.getQuad(4));
-        assertEquals(downLeftChild.getQuad(4).findTopQuad(), downLeftChild.getQuad(3));
+        assertEquals(downLeftChild.getQuad(1).findQuad(DIR_TOP), topLeftChild.getQuad(2));
+        assertEquals(downLeftChild.getQuad(2).findQuad(DIR_TOP), downLeftChild.getQuad(1));
+        assertEquals(downLeftChild.getQuad(3).findQuad(DIR_TOP), topLeftChild.getQuad(4));
+        assertEquals(downLeftChild.getQuad(4).findQuad(DIR_TOP), downLeftChild.getQuad(3));
 
         // Check non-existing neighbour quads
-        assertEquals(topLeftChild.getQuad(1).findTopQuad(), null);
-        assertEquals(topLeftChild.getQuad(3).findTopQuad(), null);
+        assertEquals(topLeftChild.getQuad(1).findQuad(DIR_TOP), null);
+        assertEquals(topLeftChild.getQuad(3).findQuad(DIR_TOP), null);
     }
 
     @Test
@@ -220,7 +222,7 @@ public class TerrainQuadTest {
             assertEquals(e.getClass(), NullPointerException.class);
         }
 
-        assertEquals(topLeftChild.findRightQuad(), topRightChild); // Confirm position of two parent quads
+        assertEquals(topLeftChild.findQuad(DIR_RIGHT), topRightChild); // Confirm position of two parent quads
 
         // Check quad children of parent
         TerrainPatch child1 = topLeftChild.findRightPatch(topLeftChild.getPatch(1));
@@ -258,7 +260,7 @@ public class TerrainQuadTest {
             assertEquals(e.getClass(), NullPointerException.class);
         }
 
-        assertEquals(topLeftChild.findDownQuad(), bottomLeftChild); // Confirm position of two parent quads
+        assertEquals(topLeftChild.findQuad(DIR_DOWN), bottomLeftChild); // Confirm position of two parent quads
 
         // Check quad children of parent
         TerrainPatch child1 = topLeftChild.findDownPatch(topLeftChild.getPatch(1));
@@ -296,7 +298,7 @@ public class TerrainQuadTest {
             assertEquals(e.getClass(), NullPointerException.class);
         }
 
-        assertEquals(topRightChild.findLeftQuad(), topLeftChild); // Confirm position of two parent quads
+        assertEquals(topRightChild.findQuad(DIR_LEFT), topLeftChild); // Confirm position of two parent quads
 
         // Check quad children of parent
         TerrainPatch child1 = topRightChild.findLeftPatch(topRightChild.getPatch(1));
@@ -334,7 +336,7 @@ public class TerrainQuadTest {
             assertEquals(e.getClass(), NullPointerException.class);
         }
 
-        assertEquals(bottomRightChild.findTopQuad(), topRightChild); // Confirm position of two parent quads
+        assertEquals(bottomRightChild.findQuad(DIR_TOP), topRightChild); // Confirm position of two parent quads
 
         // Check quad children of parent
         TerrainPatch child1 = bottomRightChild.findTopPatch(bottomRightChild.getPatch(1));
@@ -362,13 +364,12 @@ public class TerrainQuadTest {
 
     @Test
     public void testFindQuad() {
-        int DIR_RIGHT = 0, DIR_DOWN = 1, DIR_LEFT = 2, DIR_TOP = 3;
-
         FakeTerrainQuad root = (FakeTerrainQuad)createNestedQuad(2);
 
         assertEquals(root.quadrant, 0);
 
-        assertEquals(root.findQuad(-1), null);
+        assertNull(root.findQuad(-1));
+        assertNull(root.getQuad(1).findQuad(-1));
 
         assertEquals(root.findQuad(DIR_RIGHT), root.findRightQuad());
         assertEquals(root.findQuad(DIR_DOWN), root.findDownQuad());

--- a/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainQuadTest.java
+++ b/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainQuadTest.java
@@ -196,13 +196,16 @@ public class TerrainQuadTest {
         FakeTerrainQuad topLeftChild = (FakeTerrainQuad)root.getQuad(1);
         FakeTerrainQuad topRightChild = (FakeTerrainQuad)root.getQuad(3);
 
-        exception.expect(NullPointerException.class);
-        root.findRightPatch(null);
+        try {
+            root.findRightPatch(null);
+        } catch (RuntimeException e) {
+            assertEquals(e.getClass(), NullPointerException.class);
+        }
 
         assertEquals(topLeftChild.findRightQuad(), topRightChild); // Confirm position of two parent quads
 
         // Check quad children of parent
-        TerrainPatch child1 = topLeftChild.findRightPatch(topLeftChild.getPatch(2));
+        TerrainPatch child1 = topLeftChild.findRightPatch(topLeftChild.getPatch(1));
         assertNotNull(child1);
         assertEquals(child1, topLeftChild.getPatch(3));
 
@@ -223,5 +226,43 @@ public class TerrainQuadTest {
         // Check non-existing neighbour quads
         assertEquals(topRightChild.findRightPatch(topRightChild.getPatch(3)), null);
         assertEquals(topRightChild.findRightPatch(topRightChild.getPatch(4)), null);
+    }
+
+    @Test
+    public void testFindDownPatch() {
+        FakeTerrainQuad root = (FakeTerrainQuad)createNestedQuad(2);
+        FakeTerrainQuad topLeftChild = (FakeTerrainQuad)root.getQuad(1);
+        FakeTerrainQuad bottomLeftChild = (FakeTerrainQuad)root.getQuad(2);
+
+        try {
+            root.findDownPatch(null);
+        } catch (RuntimeException e) {
+            assertEquals(e.getClass(), NullPointerException.class);
+        }
+
+        assertEquals(topLeftChild.findDownQuad(), bottomLeftChild); // Confirm position of two parent quads
+
+        // Check quad children of parent
+        TerrainPatch child1 = topLeftChild.findDownPatch(topLeftChild.getPatch(1));
+        assertNotNull(child1);
+        assertEquals(child1, topLeftChild.getPatch(2));
+
+        TerrainPatch child2 = topLeftChild.findDownPatch(topLeftChild.getPatch(2));
+        assertNotNull(child1);
+        assertEquals(child2, bottomLeftChild.getPatch(1));
+
+
+        TerrainPatch child3 = topLeftChild.findDownPatch(topLeftChild.getPatch(3));
+        assertNotNull(child3);
+        assertEquals(child3, topLeftChild.getPatch(4));
+
+
+        TerrainPatch child4 = topLeftChild.findDownPatch(topLeftChild.getPatch(4));
+        assertNotNull(child4);
+        assertEquals(child4, bottomLeftChild.getPatch(3));
+
+        // Check non-existing neighbour quads
+        assertEquals(bottomLeftChild.findDownPatch(bottomLeftChild.getPatch(2)), null);
+        assertEquals(bottomLeftChild.findDownPatch(bottomLeftChild.getPatch(4)), null);
     }
 }

--- a/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainQuadTest.java
+++ b/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainQuadTest.java
@@ -124,18 +124,18 @@ public class TerrainQuadTest {
         FakeTerrainQuad topLeftChild = (FakeTerrainQuad) root.getQuad(1);
         FakeTerrainQuad topRight = (FakeTerrainQuad) root.getQuad(3);
 
-        assertEquals(root.findQuad(DIR_RIGHT), null);
-        assertEquals(topLeftChild.findQuad(DIR_RIGHT), topRight); // Confirm position of two parent quads
+        assertEquals(root.findRightQuad(), null);
+        assertEquals(topLeftChild.findRightQuad(), topRight); // Confirm position of two parent quads
 
         // Check quad children of parent
-        assertEquals(topLeftChild.getQuad(1).findQuad(DIR_RIGHT), topLeftChild.getQuad(3));
-        assertEquals(topLeftChild.getQuad(2).findQuad(DIR_RIGHT), topLeftChild.getQuad(4));
-        assertEquals(topLeftChild.getQuad(3).findQuad(DIR_RIGHT), topRight.getQuad(1));
-        assertEquals(topLeftChild.getQuad(4).findQuad(DIR_RIGHT), topRight.getQuad(2));
+        assertEquals(topLeftChild.getQuad(1).findRightQuad(), topLeftChild.getQuad(3));
+        assertEquals(topLeftChild.getQuad(2).findRightQuad(), topLeftChild.getQuad(4));
+        assertEquals(topLeftChild.getQuad(3).findRightQuad(), topRight.getQuad(1));
+        assertEquals(topLeftChild.getQuad(4).findRightQuad(), topRight.getQuad(2));
 
         // Check non-existing neighbour quads
-        assertEquals(topRight.getQuad(3).findQuad(DIR_RIGHT), null);
-        assertEquals(topRight.getQuad(4).findQuad(DIR_RIGHT), null);
+        assertEquals(topRight.getQuad(3).findRightQuad(), null);
+        assertEquals(topRight.getQuad(4).findRightQuad(), null);
     }
 
     @Test
@@ -144,18 +144,18 @@ public class TerrainQuadTest {
         FakeTerrainQuad topLeftChild = (FakeTerrainQuad) root.getQuad(1);
         FakeTerrainQuad downLeftChild = (FakeTerrainQuad) root.getQuad(2);
 
-        assertEquals(root.findQuad(DIR_DOWN), null);
-        assertEquals(topLeftChild.findQuad(DIR_DOWN), downLeftChild); // Confirm position of two parent quads
+        assertEquals(root.findDownQuad(), null);
+        assertEquals(topLeftChild.findDownQuad(), downLeftChild); // Confirm position of two parent quads
 
         // Check quad children of parent
-        assertEquals(topLeftChild.getQuad(1).findQuad(DIR_DOWN), topLeftChild.getQuad(2));
-        assertEquals(topLeftChild.getQuad(2).findQuad(DIR_DOWN), downLeftChild.getQuad(1));
-        assertEquals(topLeftChild.getQuad(3).findQuad(DIR_DOWN), topLeftChild.getQuad(4));
-        assertEquals(topLeftChild.getQuad(4).findQuad(DIR_DOWN), downLeftChild.getQuad(3));
+        assertEquals(topLeftChild.getQuad(1).findDownQuad(), topLeftChild.getQuad(2));
+        assertEquals(topLeftChild.getQuad(2).findDownQuad(), downLeftChild.getQuad(1));
+        assertEquals(topLeftChild.getQuad(3).findDownQuad(), topLeftChild.getQuad(4));
+        assertEquals(topLeftChild.getQuad(4).findDownQuad(), downLeftChild.getQuad(3));
 
         // Check non-existing neighbour quads
-        assertEquals(downLeftChild.getQuad(2).findQuad(DIR_DOWN), null);
-        assertEquals(downLeftChild.getQuad(4).findQuad(DIR_DOWN), null);
+        assertEquals(downLeftChild.getQuad(2).findDownQuad(), null);
+        assertEquals(downLeftChild.getQuad(4).findDownQuad(), null);
     }
 
     @Test
@@ -164,18 +164,18 @@ public class TerrainQuadTest {
         FakeTerrainQuad topLeftChild = (FakeTerrainQuad) root.getQuad(1);
         FakeTerrainQuad topRightChild = (FakeTerrainQuad) root.getQuad(3);
 
-        assertEquals(root.findQuad(DIR_LEFT), null);
-        assertEquals(topRightChild.findQuad(DIR_LEFT), topLeftChild); // Confirm position of two parent quads
+        assertEquals(root.findLeftQuad(), null);
+        assertEquals(topRightChild.findLeftQuad(), topLeftChild); // Confirm position of two parent quads
 
         // Check quad children of parent
-        assertEquals(topRightChild.getQuad(1).findQuad(DIR_LEFT), topLeftChild.getQuad(3));
-        assertEquals(topRightChild.getQuad(2).findQuad(DIR_LEFT), topLeftChild.getQuad(4));
-        assertEquals(topRightChild.getQuad(3).findQuad(DIR_LEFT), topRightChild.getQuad(1));
-        assertEquals(topRightChild.getQuad(4).findQuad(DIR_LEFT), topRightChild.getQuad(2));
+        assertEquals(topRightChild.getQuad(1).findLeftQuad(), topLeftChild.getQuad(3));
+        assertEquals(topRightChild.getQuad(2).findLeftQuad(), topLeftChild.getQuad(4));
+        assertEquals(topRightChild.getQuad(3).findLeftQuad(), topRightChild.getQuad(1));
+        assertEquals(topRightChild.getQuad(4).findLeftQuad(), topRightChild.getQuad(2));
 
         // Check non-existing neighbour quads
-        assertEquals(topLeftChild.getQuad(1).findQuad(DIR_LEFT), null);
-        assertEquals(topLeftChild.getQuad(2).findQuad(DIR_LEFT), null);
+        assertEquals(topLeftChild.getQuad(1).findLeftQuad(), null);
+        assertEquals(topLeftChild.getQuad(2).findLeftQuad(), null);
     }
 
     @Test
@@ -184,18 +184,18 @@ public class TerrainQuadTest {
         FakeTerrainQuad topLeftChild = (FakeTerrainQuad) root.getQuad(1);
         FakeTerrainQuad downLeftChild = (FakeTerrainQuad) root.getQuad(2);
 
-        assertEquals(root.findQuad(DIR_TOP), null);
-        assertEquals(downLeftChild.findQuad(DIR_TOP), topLeftChild); // Confirm position of two parent quads
+        assertEquals(root.findTopQuad(), null);
+        assertEquals(downLeftChild.findTopQuad(), topLeftChild); // Confirm position of two parent quads
 
         // Check quad children of parent
-        assertEquals(downLeftChild.getQuad(1).findQuad(DIR_TOP), topLeftChild.getQuad(2));
-        assertEquals(downLeftChild.getQuad(2).findQuad(DIR_TOP), downLeftChild.getQuad(1));
-        assertEquals(downLeftChild.getQuad(3).findQuad(DIR_TOP), topLeftChild.getQuad(4));
-        assertEquals(downLeftChild.getQuad(4).findQuad(DIR_TOP), downLeftChild.getQuad(3));
+        assertEquals(downLeftChild.getQuad(1).findTopQuad(), topLeftChild.getQuad(2));
+        assertEquals(downLeftChild.getQuad(2).findTopQuad(), downLeftChild.getQuad(1));
+        assertEquals(downLeftChild.getQuad(3).findTopQuad(), topLeftChild.getQuad(4));
+        assertEquals(downLeftChild.getQuad(4).findTopQuad(), downLeftChild.getQuad(3));
 
         // Check non-existing neighbour quads
-        assertEquals(topLeftChild.getQuad(1).findQuad(DIR_TOP), null);
-        assertEquals(topLeftChild.getQuad(3).findQuad(DIR_TOP), null);
+        assertEquals(topLeftChild.getQuad(1).findTopQuad(), null);
+        assertEquals(topLeftChild.getQuad(3).findTopQuad(), null);
     }
 
     @Test

--- a/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainQuadTest.java
+++ b/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainQuadTest.java
@@ -99,6 +99,24 @@ public class TerrainQuadTest {
     }
 
     @Test
+    public void testFindQuadNeighbourFinder() {
+        FakeTerrainQuad[] roots = new FakeTerrainQuad[4];
+        roots[0] = (FakeTerrainQuad) createNestedQuad(2);
+        roots[1] = (FakeTerrainQuad) createNestedQuad(2);
+        roots[2] = (FakeTerrainQuad) createNestedQuad(2);
+        roots[3] = (FakeTerrainQuad) createNestedQuad(2);
+
+        NeighbourFinder nf = new TestNeighbourFinder(roots[0], roots[1], roots[2], roots[3]);
+        for (FakeTerrainQuad root : roots) {
+            root.setNeighbourFinder(nf);
+            assertEquals(root.findQuad(0), nf.getRightQuad(root));
+            assertEquals(root.findQuad(1), nf.getDownQuad(root));
+            assertEquals(root.findQuad(2), nf.getLeftQuad(root));
+            assertEquals(root.findQuad(3), nf.getTopQuad(root));
+        }
+    }
+
+    @Test
     public void testFindRightQuad() {
         FakeTerrainQuad root = (FakeTerrainQuad) createNestedQuad(3);
         FakeTerrainQuad topLeftChild = (FakeTerrainQuad) root.getQuad(1);

--- a/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainQuadTest.java
+++ b/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainQuadTest.java
@@ -181,11 +181,12 @@ public class TerrainQuadTest {
     @Test
     public void testGetPatch() {
         FakeTerrainQuad root = (FakeTerrainQuad) createNestedQuad(1);
-        assertEquals(root.getPatch(0), null);
-        assertEquals(root.getPatch(1), root.getChild(0));
-        assertEquals(root.getPatch(2), root.getChild(1));
-        assertEquals(root.getPatch(3), root.getChild(2));
-        assertEquals(root.getPatch(4), root.getChild(3));
+        assertNull(root.getPatch(0));
+        for (int i = 1; i <= 4; i++) {
+            TerrainPatch child = root.getPatch(i);
+            assertNotNull(child);
+            assertEquals(root.getChild(i - 1), child);
+        }
         assertEquals(root.getPatch(5), null);
     }
 
@@ -201,10 +202,23 @@ public class TerrainQuadTest {
         assertEquals(topLeftChild.findRightQuad(), topRightChild); // Confirm position of two parent quads
 
         // Check quad children of parent
-        assertEquals(topLeftChild.findRightPatch(topLeftChild.getPatch(1)), topLeftChild.getPatch(3));
-        assertEquals(topLeftChild.findRightPatch(topLeftChild.getPatch(2)), topLeftChild.getPatch(4));
-        assertEquals(topLeftChild.findRightPatch(topLeftChild.getPatch(3)), topRightChild.getPatch(1));
-        assertEquals(topLeftChild.findRightPatch(topLeftChild.getPatch(4)), topRightChild.getPatch(2));
+        TerrainPatch child1 = topLeftChild.findRightPatch(topLeftChild.getPatch(2));
+        assertNotNull(child1);
+        assertEquals(child1, topLeftChild.getPatch(3));
+
+        TerrainPatch child2 = topLeftChild.findRightPatch(topLeftChild.getPatch(2));
+        assertNotNull(child1);
+        assertEquals(child2, topLeftChild.getPatch(4));
+
+
+        TerrainPatch child3 = topLeftChild.findRightPatch(topLeftChild.getPatch(3));
+        assertNotNull(child3);
+        assertEquals(child3, topRightChild.getPatch(1));
+
+
+        TerrainPatch child4 = topLeftChild.findRightPatch(topLeftChild.getPatch(4));
+        assertNotNull(child4);
+        assertEquals(child4, topRightChild.getPatch(2));
 
         // Check non-existing neighbour quads
         assertEquals(topRightChild.findRightPatch(topRightChild.getPatch(3)), null);

--- a/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainQuadTest.java
+++ b/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainQuadTest.java
@@ -4,9 +4,14 @@ import static org.junit.Assert.*;
 
 import com.jme3.scene.Spatial;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class TerrainQuadTest {
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
 
     private FakeTerrainQuad parentTerrainQuad;
     private FakeTerrainQuad[] children = new FakeTerrainQuad[4];
@@ -182,5 +187,27 @@ public class TerrainQuadTest {
         assertEquals(root.getPatch(3), root.getChild(2));
         assertEquals(root.getPatch(4), root.getChild(3));
         assertEquals(root.getPatch(5), null);
+    }
+
+    @Test
+    public void testFindRightPatch() {
+        FakeTerrainQuad root = (FakeTerrainQuad)createNestedQuad(2);
+        FakeTerrainQuad topLeftChild = (FakeTerrainQuad)root.getQuad(1);
+        FakeTerrainQuad topRightChild = (FakeTerrainQuad)root.getQuad(3);
+
+        exception.expect(NullPointerException.class);
+        root.findRightPatch(null);
+
+        assertEquals(topLeftChild.findRightQuad(), topRightChild); // Confirm position of two parent quads
+
+        // Check quad children of parent
+        assertEquals(topLeftChild.findRightPatch(topLeftChild.getPatch(1)), topLeftChild.getPatch(3));
+        assertEquals(topLeftChild.findRightPatch(topLeftChild.getPatch(2)), topLeftChild.getPatch(4));
+        assertEquals(topLeftChild.findRightPatch(topLeftChild.getPatch(3)), topRightChild.getPatch(1));
+        assertEquals(topLeftChild.findRightPatch(topLeftChild.getPatch(4)), topRightChild.getPatch(2));
+
+        // Check non-existing neighbour quads
+        assertEquals(topRightChild.findRightPatch(topRightChild.getPatch(3)), null);
+        assertEquals(topRightChild.findRightPatch(topRightChild.getPatch(4)), null);
     }
 }

--- a/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainQuadTest.java
+++ b/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainQuadTest.java
@@ -13,7 +13,7 @@ public class TerrainQuadTest {
 
     @Before
     public void init() {
-        for(int i = 0; i < 4; i++) {
+        for (int i = 0; i < 4; i++) {
             children[i] = new FakeTerrainQuad();
         }
 
@@ -32,6 +32,7 @@ public class TerrainQuadTest {
      * Used to recursively create a nested structure of {@link Spatial}s.
      * If nesting level is > 1, root element will be a {@link TerrainQuad}.
      * Leafs (nesting level 0) are {@link TerrainPatch}es.
+     *
      * @param nestLevel Nest level to be created.
      * @return Nested structure of {@link Spatial}s
      */
@@ -41,7 +42,7 @@ public class TerrainQuadTest {
         }
 
         FakeTerrainQuad parent = new FakeTerrainQuad();
-        for(int i = 0; i < 4; i++) {
+        for (int i = 0; i < 4; i++) {
             Spatial child = createNestedQuad(nestLevel - 1);
 
             if (child instanceof TerrainPatch) {
@@ -71,13 +72,13 @@ public class TerrainQuadTest {
 
         FakeTerrainQuad root = (FakeTerrainQuad) createNestedQuad(1);
         assertEquals(root.getChildren().size(), 4);
-        for(int i = 0; i < 4; i++) {
+        for (int i = 0; i < 4; i++) {
             assertTrue(root.getChild(i) instanceof TerrainPatch); // Ensure children of root are leafs
         }
 
         root = (FakeTerrainQuad) createNestedQuad(2);
         assertEquals(root.getChildren().size(), 4);
-        for(int i = 0; i < 4; i++) {
+        for (int i = 0; i < 4; i++) {
             assertTrue(root.getChild(i) instanceof TerrainQuad); // Ensure children of root are not leafs
         }
     }
@@ -94,9 +95,9 @@ public class TerrainQuadTest {
 
     @Test
     public void testFindRightQuad() {
-        FakeTerrainQuad root = (FakeTerrainQuad)createNestedQuad(3);
-        FakeTerrainQuad topLeftChild = (FakeTerrainQuad)root.getQuad(1);
-        FakeTerrainQuad topRight = (FakeTerrainQuad)root.getQuad(3);
+        FakeTerrainQuad root = (FakeTerrainQuad) createNestedQuad(3);
+        FakeTerrainQuad topLeftChild = (FakeTerrainQuad) root.getQuad(1);
+        FakeTerrainQuad topRight = (FakeTerrainQuad) root.getQuad(3);
 
         assertEquals(root.findRightQuad(), null);
         assertEquals(topLeftChild.findRightQuad(), topRight); // Confirm position of two parent quads
@@ -114,9 +115,9 @@ public class TerrainQuadTest {
 
     @Test
     public void testFindDownQuad() {
-        FakeTerrainQuad root = (FakeTerrainQuad)createNestedQuad(3);
-        FakeTerrainQuad topLeftChild = (FakeTerrainQuad)root.getQuad(1);
-        FakeTerrainQuad downLeftChild = (FakeTerrainQuad)root.getQuad(2);
+        FakeTerrainQuad root = (FakeTerrainQuad) createNestedQuad(3);
+        FakeTerrainQuad topLeftChild = (FakeTerrainQuad) root.getQuad(1);
+        FakeTerrainQuad downLeftChild = (FakeTerrainQuad) root.getQuad(2);
 
         assertEquals(root.findDownQuad(), null);
         assertEquals(topLeftChild.findDownQuad(), downLeftChild); // Confirm position of two parent quads
@@ -134,9 +135,9 @@ public class TerrainQuadTest {
 
     @Test
     public void testFindLeftQuad() {
-        FakeTerrainQuad root = (FakeTerrainQuad)createNestedQuad(3);
-        FakeTerrainQuad topLeftChild = (FakeTerrainQuad)root.getQuad(1);
-        FakeTerrainQuad topRightChild = (FakeTerrainQuad)root.getQuad(3);
+        FakeTerrainQuad root = (FakeTerrainQuad) createNestedQuad(3);
+        FakeTerrainQuad topLeftChild = (FakeTerrainQuad) root.getQuad(1);
+        FakeTerrainQuad topRightChild = (FakeTerrainQuad) root.getQuad(3);
 
         assertEquals(root.findLeftQuad(), null);
         assertEquals(topRightChild.findLeftQuad(), topLeftChild); // Confirm position of two parent quads
@@ -154,9 +155,9 @@ public class TerrainQuadTest {
 
     @Test
     public void testFindTopQuad() {
-        FakeTerrainQuad root = (FakeTerrainQuad)createNestedQuad(3);
-        FakeTerrainQuad topLeftChild = (FakeTerrainQuad)root.getQuad(1);
-        FakeTerrainQuad downLeftChild = (FakeTerrainQuad)root.getQuad(2);
+        FakeTerrainQuad root = (FakeTerrainQuad) createNestedQuad(3);
+        FakeTerrainQuad topLeftChild = (FakeTerrainQuad) root.getQuad(1);
+        FakeTerrainQuad downLeftChild = (FakeTerrainQuad) root.getQuad(2);
 
         assertEquals(root.findTopQuad(), null);
         assertEquals(downLeftChild.findTopQuad(), topLeftChild); // Confirm position of two parent quads
@@ -170,5 +171,16 @@ public class TerrainQuadTest {
         // Check non-existing neighbour quads
         assertEquals(topLeftChild.getQuad(1).findTopQuad(), null);
         assertEquals(topLeftChild.getQuad(3).findTopQuad(), null);
+    }
+
+    @Test
+    public void testGetPatch() {
+        FakeTerrainQuad root = (FakeTerrainQuad) createNestedQuad(1);
+        assertEquals(root.getPatch(0), null);
+        assertEquals(root.getPatch(1), root.getChild(0));
+        assertEquals(root.getPatch(2), root.getChild(1));
+        assertEquals(root.getPatch(3), root.getChild(2));
+        assertEquals(root.getPatch(4), root.getChild(3));
+        assertEquals(root.getPatch(5), null);
     }
 }

--- a/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainQuadTest.java
+++ b/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainQuadTest.java
@@ -265,4 +265,80 @@ public class TerrainQuadTest {
         assertEquals(bottomLeftChild.findDownPatch(bottomLeftChild.getPatch(2)), null);
         assertEquals(bottomLeftChild.findDownPatch(bottomLeftChild.getPatch(4)), null);
     }
+
+    @Test
+    public void testFindLeftPatch() {
+        FakeTerrainQuad root = (FakeTerrainQuad)createNestedQuad(2);
+        FakeTerrainQuad topLeftChild = (FakeTerrainQuad)root.getQuad(1);
+        FakeTerrainQuad topRightChild = (FakeTerrainQuad)root.getQuad(3);
+
+        try {
+            root.findLeftPatch(null);
+        } catch (RuntimeException e) {
+            assertEquals(e.getClass(), NullPointerException.class);
+        }
+
+        assertEquals(topRightChild.findLeftQuad(), topLeftChild); // Confirm position of two parent quads
+
+        // Check quad children of parent
+        TerrainPatch child1 = topRightChild.findLeftPatch(topRightChild.getPatch(1));
+        assertNotNull(child1);
+        assertEquals(child1, topLeftChild.getPatch(3));
+
+        TerrainPatch child2 = topRightChild.findLeftPatch(topRightChild.getPatch(2));
+        assertNotNull(child1);
+        assertEquals(child2, topLeftChild.getPatch(4));
+
+
+        TerrainPatch child3 = topRightChild.findLeftPatch(topRightChild.getPatch(3));
+        assertNotNull(child3);
+        assertEquals(child3, topRightChild.getPatch(1));
+
+
+        TerrainPatch child4 = topRightChild.findLeftPatch(topRightChild.getPatch(4));
+        assertNotNull(child4);
+        assertEquals(child4, topRightChild.getPatch(2));
+
+        // Check non-existing neighbour quads
+        assertEquals(topLeftChild.findLeftPatch(topLeftChild.getPatch(1)), null);
+        assertEquals(topLeftChild.findLeftPatch(topLeftChild.getPatch(2)), null);
+    }
+
+    @Test
+    public void testFindTopPatch() {
+        FakeTerrainQuad root = (FakeTerrainQuad)createNestedQuad(2);
+        FakeTerrainQuad topRightChild = (FakeTerrainQuad)root.getQuad(3);
+        FakeTerrainQuad bottomRightChild = (FakeTerrainQuad)root.getQuad(4);
+
+        try {
+            root.findTopPatch(null);
+        } catch (RuntimeException e) {
+            assertEquals(e.getClass(), NullPointerException.class);
+        }
+
+        assertEquals(bottomRightChild.findTopQuad(), topRightChild); // Confirm position of two parent quads
+
+        // Check quad children of parent
+        TerrainPatch child1 = bottomRightChild.findTopPatch(bottomRightChild.getPatch(1));
+        assertNotNull(child1);
+        assertEquals(child1, topRightChild.getPatch(2));
+
+        TerrainPatch child2 = bottomRightChild.findTopPatch(bottomRightChild.getPatch(2));
+        assertNotNull(child1);
+        assertEquals(child2, bottomRightChild.getPatch(1));
+
+
+        TerrainPatch child3 = bottomRightChild.findTopPatch(bottomRightChild.getPatch(3));
+        assertNotNull(child3);
+        assertEquals(child3, topRightChild.getPatch(4));
+
+
+        TerrainPatch child4 = bottomRightChild.findTopPatch(bottomRightChild.getPatch(4));
+        assertNotNull(child4);
+        assertEquals(child4, bottomRightChild.getPatch(3));
+
+        // Check non-existing neighbour quads
+        assertEquals(topRightChild.findTopPatch(topRightChild.getPatch(1)), null);
+        assertEquals(topRightChild.findTopPatch(topRightChild.getPatch(3)), null);
+    }
 }

--- a/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainQuadTest.java
+++ b/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainQuadTest.java
@@ -341,4 +341,28 @@ public class TerrainQuadTest {
         assertEquals(topRightChild.findTopPatch(topRightChild.getPatch(1)), null);
         assertEquals(topRightChild.findTopPatch(topRightChild.getPatch(3)), null);
     }
+
+    @Test
+    public void testFindQuad() {
+        int DIR_RIGHT = 0, DIR_DOWN = 1, DIR_LEFT = 2, DIR_TOP = 3;
+
+        FakeTerrainQuad root = (FakeTerrainQuad)createNestedQuad(2);
+
+        assertEquals(root.quadrant, 0);
+
+        assertEquals(root.findQuad(-1), null);
+
+        assertEquals(root.findQuad(DIR_RIGHT), root.findRightQuad());
+        assertEquals(root.findQuad(DIR_DOWN), root.findDownQuad());
+        assertEquals(root.findQuad(DIR_LEFT), root.findLeftQuad());
+        assertEquals(root.findQuad(DIR_TOP), root.findTopQuad());
+
+        for(int i = 0; i < root.getChildren().size(); i++) {
+            FakeTerrainQuad child = (FakeTerrainQuad)root.getQuad(i);
+            assertEquals(child.findQuad(DIR_RIGHT), child.findRightQuad());
+            assertEquals(child.findQuad(DIR_DOWN), child.findDownQuad());
+            assertEquals(child.findQuad(DIR_LEFT), child.findLeftQuad());
+            assertEquals(child.findQuad(DIR_TOP), child.findTopQuad());
+        }
+    }
 }

--- a/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainQuadTest.java
+++ b/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TerrainQuadTest.java
@@ -111,10 +111,17 @@ public class TerrainQuadTest {
         NeighbourFinder nf = new TestNeighbourFinder(roots[0], roots[1], roots[2], roots[3]);
         for (FakeTerrainQuad root : roots) {
             root.setNeighbourFinder(nf);
-            assertEquals(root.findQuad(0), nf.getRightQuad(root));
-            assertEquals(root.findQuad(1), nf.getDownQuad(root));
-            assertEquals(root.findQuad(2), nf.getLeftQuad(root));
-            assertEquals(root.findQuad(3), nf.getTopQuad(root));
+            // Legacy code
+            assertEquals(root.findRightQuad(), nf.getRightQuad(root));
+            assertEquals(root.findDownQuad(), nf.getDownQuad(root));
+            assertEquals(root.findLeftQuad(), nf.getLeftQuad(root));
+            assertEquals(root.findTopQuad(), nf.getTopQuad(root));
+
+            // Refactored code
+            assertEquals(root.findQuad(DIR_RIGHT), nf.getRightQuad(root));
+            assertEquals(root.findQuad(DIR_DOWN), nf.getDownQuad(root));
+            assertEquals(root.findQuad(DIR_LEFT), nf.getLeftQuad(root));
+            assertEquals(root.findQuad(DIR_TOP), nf.getTopQuad(root));
         }
     }
 

--- a/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TestNeighbourFinder.java
+++ b/jme3-terrain/src/test/java/com/jme3/terrain/geomipmap/TestNeighbourFinder.java
@@ -1,0 +1,61 @@
+package com.jme3.terrain.geomipmap;
+
+public class TestNeighbourFinder implements NeighbourFinder {
+
+    TerrainQuad quad1, quad2, quad3, quad4;
+
+    public TestNeighbourFinder(TerrainQuad quad1, TerrainQuad quad2, TerrainQuad quad3, TerrainQuad quad4) {
+        this.quad1 = quad1;
+        this.quad2 = quad2;
+        this.quad3 = quad3;
+        this.quad4 = quad4;
+    }
+
+    @Override
+    public TerrainQuad getRightQuad(TerrainQuad center) {
+        if (center == quad1) {
+            return quad3;
+        }
+        if (center == quad2) {
+            return quad4;
+        }
+
+        return null;
+    }
+
+    @Override
+    public TerrainQuad getLeftQuad(TerrainQuad center) {
+        if (center == quad3) {
+            return quad1;
+        }
+        if (center == quad4) {
+            return quad2;
+        }
+
+        return null;
+    }
+
+    @Override
+    public TerrainQuad getTopQuad(TerrainQuad center) {
+        if (center == quad2) {
+            return quad1;
+        }
+        if (center == quad4) {
+            return quad3;
+        }
+
+        return null;
+    }
+
+    @Override
+    public TerrainQuad getDownQuad(TerrainQuad center) {
+        if (center == quad1) {
+            return quad2;
+        }
+        if (center == quad3) {
+            return quad4;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
The following methods have been recovered to the `TerrainQuad findQuad(int direction)` method:
- `TerrainQuad findRightQuad()`
- `TerrainQuad findDownQuad()`
- `TerrainQuad findLeftQuad()`
- `TerrainQuad findTopQuad()`

The following methods have been recovered to the `TerrainPatch findPatch(int direction)` method:
- `TerrainQuad findRightPatch()`
- `TerrainQuad findDownPatch()`
- `TerrainQuad findLeftPatch()`
- `TerrainQuad findTopPatch()`

The two new methods are accompanied by several private methods, replacing the functionality of the methods listed above. These methods have the findXNeighbourPatch or findXNeighbourQuad.
### Testing

Tests have been created to cover the functionality of the legacy code. To ensure that the new code returns the same results as the legacy code, the tests `testFindQuad` and `testFindPatch` have been created. These tests compare all possible results from both the legacy code and the refactored code. 

Other tests found in the `TerrainQuadTest.java` and `TerrainPatchTest.java` files have been created to improve our understanding of the legacy code. These also provide 100% coverage of both the legacy code and the refactored code.
